### PR TITLE
Introduce `wp rest help` for rendering API docs in different formats

### DIFF
--- a/inc/HelpCommand.php
+++ b/inc/HelpCommand.php
@@ -28,13 +28,8 @@ class HelpCommand {
 	 * Display the index as API blueprint
 	 */
 	private function display_index_as_api_blueprint() {
-		$schemas = array();
-		foreach( $this->api_index['routes'] as $route => $data ) {
-			if ( ! empty( $data['schema'] ) ) {
-				$schemas[ $data['schema']['title'] ] = $data['schema'];
-			}
-		}
 		$output = array();
+		$schemas = $this->get_schemas();
 		if ( ! empty( $schemas ) ) {
 			$output[] = '# Data Structures';
 			$output[] = '';
@@ -62,6 +57,16 @@ class HelpCommand {
 			}
 		}
 		echo implode( PHP_EOL, $output );
+	}
+
+	private function get_schemas() {
+		$schemas = array();
+		foreach( $this->api_index['routes'] as $route => $data ) {
+			if ( ! empty( $data['schema'] ) ) {
+				$schemas[ $data['schema']['title'] ] = $data['schema'];
+			}
+		}
+		return $schemas;
 	}
 
 }

--- a/inc/HelpCommand.php
+++ b/inc/HelpCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WP_REST_CLI;
+
+class HelpCommand {
+
+	private $ap_index = array();
+
+	public function __construct( $api_index ) {
+		$this->api_index = $api_index;
+	}
+
+	/**
+	 * Explain this API in human-readable terms.
+	 *
+	 * [--format=<format>]
+	 * : Display API details in a particular format.
+	 *
+	 * @when before_wp_load
+	 */
+	public function help( $args, $assoc_args ) {
+		if ( 'apib' === $assoc_args['format'] ) {
+			$this->display_index_as_api_blueprint();
+		}
+	}
+
+	/**
+	 * Display the index as API blueprint
+	 */
+	private function display_index_as_api_blueprint() {
+		$schemas = array();
+		foreach( $this->api_index['routes'] as $route => $data ) {
+			if ( ! empty( $data['schema'] ) ) {
+				$schemas[ $data['schema']['title'] ] = $data['schema'];
+			}
+		}
+		$output = array();
+		if ( ! empty( $schemas ) ) {
+			$output[] = '# Data Structures';
+			$output[] = '';
+			foreach( $schemas as $schema ) {
+				$output[] = "## {$schema['title']} ({$schema['type']})";
+				foreach( $schema['properties'] as $key => $args ) {
+					$output[] = "+ {$key}";
+				}
+				$output[] = '';
+			}
+		}
+		echo implode( PHP_EOL, $output );
+	}
+
+}

--- a/inc/HelpCommand.php
+++ b/inc/HelpCommand.php
@@ -41,7 +41,22 @@ class HelpCommand {
 			foreach( $schemas as $schema ) {
 				$output[] = "## {$schema['title']} ({$schema['type']})";
 				foreach( $schema['properties'] as $key => $args ) {
-					$output[] = "+ {$key}";
+					$bits = array();
+					if ( ! empty( $args['type'] ) ) {
+						$type = $args['type'];
+						if ( ! empty( $args['format'] ) ) {
+							$type .= '[' . $args['format'] . ']';
+						}
+						$bits[] = $type;
+					}
+					if ( ! empty( $args['required'] ) ) {
+						$bits[] = 'required';
+					}
+					if ( ! empty( $bits ) ) {
+						$bits = ' (' . implode( ', ', $bits ) . ')';
+					}
+					$description = ! empty( $args['description'] ) ? ' - ' . $args['description'] : '';
+					$output[] = "+ {$key}{$bits}{$description}";
 				}
 				$output[] = '';
 			}

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -34,6 +34,8 @@ class Runner {
 				if ( ! $api_index ) {
 					WP_CLI::error( "Couldn't find index data from {$api_url}." );
 				}
+				$help_command = new HelpCommand( $api_index );
+				WP_CLI::add_command( 'rest help', array( $help_command, 'help' ) );
 				foreach( $api_index['routes'] as $route => $route_data ) {
 					if ( empty( $route_data['schema']['title'] ) ) {
 						continue;
@@ -68,7 +70,9 @@ class Runner {
 		if ( empty( $response_data ) ) {
 			return;
 		}
-		
+
+		$help_command = new HelpCommand( $response_data );
+		WP_CLI::add_command( 'rest help', array( $help_command, 'help' ) );
 		foreach( $response_data['routes'] as $route => $route_data ) {
 			if ( empty( $route_data['schema']['title'] ) ) {
 				continue;

--- a/wp-rest-cli.php
+++ b/wp-rest-cli.php
@@ -3,6 +3,7 @@
  * Use WP-API at the command line.
  */
 
+require_once __DIR__ . '/inc/HelpCommand.php';
 require_once __DIR__ . '/inc/RestCommand.php';
 require_once __DIR__ . '/inc/Runner.php';
 


### PR DESCRIPTION
Let's start with `--format=apib`