### PR TITLE
Fix empty output when no `--context=<context>` is provided

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -31,7 +31,12 @@ Feature: Manage WordPress comments through the REST API
       1
       """
 
-  Scenario: List comments with view context
+  Scenario: List comments with different contexts
+    When I run `wp rest comment list --format=csv`
+    Then STDOUT should contain:
+      """
+      id,author,author_avatar_urls,author_name,author_url,content,date,link
+      """
     When I run `wp rest comment list --context=view --format=csv`
     Then STDOUT should contain:
       """

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -171,7 +171,7 @@ class RestCommand {
 			if ( ! empty( $assoc_args['context'] ) ) {
 				$fields = $this->get_context_fields( $assoc_args['context'] );
 			} else {
-				$fields = $this->get_context_fields( $embed );
+				$fields = $this->get_context_fields( 'embed' );
 			}
 		}
 		return new \WP_CLI\Formatter( $assoc_args, $fields );


### PR DESCRIPTION
Introduced in #26