### PR TITLE
Add a test for `wp comment list --help` output

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -19,6 +19,21 @@ Feature: Manage WordPress comments through the REST API
       update
       """
 
+    When I run `wp rest comment list --help`
+    Then STDOUT should contain:
+      """
+      [--context=<context>]
+          Scope under which the request is made; determines fields present in
+          response.
+          ---
+          default: view
+          options:
+            - view
+            - embed
+            - edit
+          ---
+      """
+
   Scenario: List all WordPress comments
     When I run `wp rest comment list --fields=id,author_name`
     Then STDOUT should be a table containing rows:


### PR DESCRIPTION
We should also have a test for `wp comment create --help`, but the description is currently missing for each argument.

See https://github.com/WP-API/WP-API/pull/2362