### PR TITLE
Use `--debug` for simple profiling of local endpoints

### DIFF
--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -133,7 +133,19 @@ class RestCommand {
 					$request->set_param( $key, $value );
 				}
 			}
+			if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+				$GLOBALS['wpdb']->queries = array();
+			}
 			$response = rest_do_request( $request );
+			if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+				$query_count = count( $GLOBALS['wpdb']->queries );
+				$query_total_time = 0;
+				foreach( $GLOBALS['wpdb']->queries as $query ) {
+					$query_total_time += $query[1];
+				}
+				$query_total_time = round( $query_total_time, 3 );
+				WP_CLI::debug( "REST command executed {$query_count} queries in {$query_total_time} seconds" );
+			}
 			if ( $error = $response->as_error() ) {
 				WP_CLI::error( $error );
 			}

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -228,9 +228,19 @@ class Runner {
 				'update'     => 'update_item',
 			);
 
+			$before_invoke = false;
+			if ( empty( $command_args['when'] ) ) {
+				$before_invoke = function() {
+					if ( ! defined( 'SAVEQUERIES' ) ) {
+						define( 'SAVEQUERIES', true );
+					}
+				};
+			}
+
 			WP_CLI::add_command( "{$parent} {$command}", array( $rest_command, $methods[ $command ] ), array(
-				'synopsis' => $synopsis,
-				'when'     => ! empty( $command_args['when'] ) ? $command_args['when'] : '',
+				'synopsis'      => $synopsis,
+				'when'          => ! empty( $command_args['when'] ) ? $command_args['when'] : '',
+				'before_invoke' => $before_invoke,
 			) );
 		}
 	}


### PR DESCRIPTION
See #42 