### PR TITLE
Only `SAVEQUERIES` when we're using `--debug`

### DIFF
--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -228,8 +228,8 @@ class Runner {
 				'update'     => 'update_item',
 			);
 
-			$before_invoke = false;
-			if ( empty( $command_args['when'] ) ) {
+			$before_invoke = null;
+			if ( empty( $command_args['when'] ) && WP_CLI::get_config( 'debug' ) ) {
 				$before_invoke = function() {
 					if ( ! defined( 'SAVEQUERIES' ) ) {
 						define( 'SAVEQUERIES', true );


### PR DESCRIPTION
Otherwise, it's an unnecessary performance hit.

See #42