### PR TITLE
When performing a CUD operation, display `id` on success

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -95,7 +95,7 @@ Feature: Manage WordPress comments through the REST API
     When I run `wp rest comment create --post=1 --content="Hello World, again" --user=1`
     Then STDOUT should contain:
       """
-      Success: Created comment.
+      Success: Created comment 2
       """
 
     When I run `wp rest comment get 2 --fields=content --format=json`
@@ -114,7 +114,7 @@ Feature: Manage WordPress comments through the REST API
     When I run `wp rest comment update 1 --content="Hello World" --user=1`
     Then STDOUT should contain:
       """
-      Success: Updated comment.
+      Success: Updated comment 1.
       """
 
     When I run `wp rest comment get 1 --fields=content --format=json`
@@ -133,11 +133,11 @@ Feature: Manage WordPress comments through the REST API
     When I run `wp rest comment delete 1 --user=1`
     Then STDOUT should contain:
       """
-      Success: Trashed comment.
+      Success: Trashed comment 1.
       """
 
     When I run `wp rest comment delete 1 --user=1 --force=true`
     Then STDOUT should contain:
       """
-      Success: Deleted comment.
+      Success: Deleted comment 1.
       """

--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -59,7 +59,7 @@ class RestCommand {
 	 */
 	public function create_item( $args, $assoc_args ) {
 		list( $status, $body ) = $this->do_request( 'POST', $this->get_base_route(), $assoc_args );
-		WP_CLI::success( "Created {$this->name}." );
+		WP_CLI::success( "Created {$this->name} {$body['id']}." );
 	}
 
 	/**
@@ -70,9 +70,9 @@ class RestCommand {
 	public function delete_item( $args, $assoc_args ) {
 		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
 		if ( empty( $assoc_args['force'] ) ) {
-			WP_CLI::success( "Trashed {$this->name}." );
+			WP_CLI::success( "Trashed {$this->name} {$body['id']}." );
 		} else {
-			WP_CLI::success( "Deleted {$this->name}." );
+			WP_CLI::success( "Deleted {$this->name} {$body['id']}." );
 		}
 	}
 
@@ -148,7 +148,7 @@ class RestCommand {
 	 */
 	public function update_item( $args, $assoc_args ) {
 		list( $status, $body ) = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
-		WP_CLI::success( "Updated {$this->name}." );
+		WP_CLI::success( "Updated {$this->name} {$body['id']}." );
 	}
 
 	/**


### PR DESCRIPTION
See #61