### PR TITLE
Don't define `REST_REQUEST` for every CLI command

### DIFF
--- a/inc/RestCommand.php
+++ b/inc/RestCommand.php
@@ -207,6 +207,9 @@ class RestCommand {
 	 */
 	private function do_request( $method, $route, $assoc_args ) {
 		if ( 'internal' === $this->scope ) {
+			if ( ! defined( 'REST_REQUEST' ) ) {
+				define( 'REST_REQUEST', true );
+			}
 			$request = new \WP_REST_Request( $method, $route );
 			if ( in_array( $method, array( 'POST', 'PUT' ) ) ) {
 				$request->set_body_params( $assoc_args );

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -65,8 +65,6 @@ class Runner {
 
 		global $wp_rest_server;
 
-		define( 'REST_REQUEST', true );
-
 		$wp_rest_server = new WP_REST_Server;
 		do_action( 'rest_api_init', $wp_rest_server );
 


### PR DESCRIPTION
It should only be defined when we're making an internal request