### PR TITLE
Support `--field=<field>` argument for `wp rest * (list|get)`

### DIFF
--- a/features/comment.feature
+++ b/features/comment.feature
@@ -78,6 +78,13 @@ Feature: Manage WordPress comments through the REST API
       11
       """
 
+  Scenario: Get the value of an individual comment field
+    When I run `wp rest comment get 1 --field=author_name`
+    Then STDOUT should be:
+      """
+      Mr WordPress
+      """
+
   Scenario: Get a specific comment
     When I run `wp rest comment get 1 --fields=id,author_name`
     Then STDOUT should be a table containing rows:

--- a/features/post.feature
+++ b/features/post.feature
@@ -4,6 +4,13 @@ Feature: Manage WordPress posts through the REST API
     Given a WP install
     And I run `wp plugin install rest-api --activate`
 
+  Scenario: Get the value of an individual post field
+    When I run `wp rest post get 1 --field=title`
+    Then STDOUT should be JSON containing:
+      """
+      {"rendered":"Hello world!"}
+      """
+
   Scenario: CUD a post with `--porcelain`
     When I run `wp rest post create --user=admin --title="Test Post" --porcelain`
     Then STDOUT should be a number

--- a/inc/Runner.php
+++ b/inc/Runner.php
@@ -210,6 +210,12 @@ class Runner {
 					'optional'    => true,
 				);
 				$synopsis[] = array(
+					'name'        => 'field',
+					'type'        => 'assoc',
+					'description' => 'Get the value of an individual field.',
+					'optional'    => true,
+				);
+				$synopsis[] = array(
 					'name'        => 'format',
 					'type'        => 'assoc',
 					'description' => 'Render response in a particular format.',


### PR DESCRIPTION
This makes it easier to get the value of an individual field

From https://github.com/wp-cli/wp-cli/issues/2727